### PR TITLE
update ProvidedTypes.fs for Mono 5.0

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -7,8 +7,8 @@ NUGET
       IKVM (8.1.5717)
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.StarterPack
-    src/ProvidedTypes.fs (252ea631e3a7d5242205d46ffdf81fc9b03de58c)
-    src/ProvidedTypes.fsi (252ea631e3a7d5242205d46ffdf81fc9b03de58c)
+    src/ProvidedTypes.fs (1dab4f94411500794342f61f877feab772e5a754)
+    src/ProvidedTypes.fsi (1dab4f94411500794342f61f877feab772e5a754)
 HTTP
   remote: http://nlp.stanford.edu
     stanford-corenlp-full-2016-10-31.zip (/software/stanford-corenlp-full-2016-10-31.zip)


### PR DESCRIPTION
A change was requested across all Type Providers that utilized `ProvidedTypes.fs` from the TP Starter Pack (see #7 and https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/121).

This file was referenced via paket, so I have updated the paket reference to point to the commit with the update, 1dab4f94411500794342f61f877feab772e5a754.